### PR TITLE
DNS for github.io site

### DIFF
--- a/community/dns.tf
+++ b/community/dns.tf
@@ -1,0 +1,12 @@
+#
+# Configure master DNS zone. Projects that need a sub-domain or individual
+# records should be configured alongside the associated resources.
+#
+
+resource "aws_route53_zone" "domain" {
+  name = "${local.domain}"
+}
+
+resource "aws_route53_zone" "domain-short" {
+  name = "${local.domain-short}"
+}

--- a/community/docs.tf
+++ b/community/docs.tf
@@ -1,0 +1,28 @@
+#
+# Configure resources for titan-data.github.io. This includes a CNAME
+# record for "www" that points to the site, as well as an "A" record for the
+# top-level domain that points to GitHub as described here:
+#
+# https://help.github.com/en/articles/setting-up-an-apex-domain
+#
+
+resource "aws_route53_record" "www" {
+  zone_id   = "${aws_route53_zone.domain.zone_id}"
+  name      = "www"
+  type      = "CNAME"
+  records   = [ "titan-data.github.io" ]
+  ttl       = "${local.dns-ttl}"
+}
+
+resource "aws_route53_record" "www-alias" {
+  zone_id   = "${aws_route53_zone.domain.zone_id}"
+  name      = ""
+  type      = "A"
+  records   = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153"
+  ]
+  ttl       = "${local.dns-ttl}"
+}

--- a/community/download.tf
+++ b/community/download.tf
@@ -13,31 +13,11 @@ resource "aws_s3_bucket" "logs" {
 # Download bucket
 resource "aws_s3_bucket" "download" {
   bucket = "${var.project}-download"
+  acl = "public-read"
   force_destroy = true
 
   logging {
     target_bucket = "${aws_s3_bucket.logs.id}"
     target_prefix = "download/"
   }
-}
-
-# Public access
-resource "aws_s3_bucket_policy" "download" {
-  bucket = "${aws_s3_bucket.download.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AddPerm",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetObject",
-
-      "Resource": "${aws_s3_bucket.download.arn}/*"
-    }
-  ]
-}
-EOF
 }

--- a/community/maven.tf
+++ b/community/maven.tf
@@ -4,25 +4,6 @@
 
 resource "aws_s3_bucket" "maven" {
   bucket = "${var.project}-maven"
+  acl = "public-read"
   force_destroy = true
-}
-
-resource "aws_s3_bucket_policy" "maven" {
-  bucket = "${aws_s3_bucket.maven.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AddPerm",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetObject",
-
-      "Resource": "${aws_s3_bucket.maven.arn}/*"
-    }
-  ]
-}
-EOF
 }

--- a/init.sh
+++ b/init.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-PROJECT=titan-data-test
+PROJECT=titan-data
 REGION=$(aws configure get region)
 BOOTSTRAP=false
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,15 @@ variable "region" {
 }
 
 variable "project" {
-  default = "titan-data-test"
+  default = "titan-data"
 }
 
 provider "aws" {
   region = "${var.region}"
+}
+
+locals {
+  domain = "${var.project}.io"
+  domain-short = replace("${var.project}.io", "-", "")
+  dns-ttl = 300
 }


### PR DESCRIPTION
## Proposed Changes

This adds DNS CNAME and A records to redirect `titan-data.io` to `titan-data.github.io`. It also cleans up some other bits and pieces, like using predefined S3 ACLs. Note that HTTPS support does not yet work, more investigation is needed.

## Testing

Deployed to community account and tested that http://titan-data.io gets properly redirected.