### PR TITLE
Add automation users

### DIFF
--- a/community/titan-server.tf
+++ b/community/titan-server.tf
@@ -1,0 +1,28 @@
+#
+# Infrastructure required for titan-server automation. This is just a user
+# with permission to write objects to the maven bucket.
+#
+
+resource "aws_iam_user" "titan-server" {
+  name = "titan-server"
+  path = "/automation/"
+}
+
+resource "aws_iam_user_policy" "titan-server-maven" {
+  name = "titan-server-maven"
+  user = "${aws_iam_user.titan-server.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+
+      "Resource": "${aws_s3_bucket.maven.arn}/*"
+    }
+  ]
+}
+EOF
+}

--- a/community/zfs-releases.tf
+++ b/community/zfs-releases.tf
@@ -1,0 +1,29 @@
+#
+# Infrastructure required for zfs-releases automation. This is just a user
+# with permission to write objects under "/zfs-releases" in the download
+# bucket.
+#
+
+resource "aws_iam_user" "zfs-releases" {
+  name = "zfs-releases"
+  path = "/automation/"
+}
+
+resource "aws_iam_user_policy" "zfs-releases-download" {
+  name = "zfs-releases-download"
+  user = "${aws_iam_user.zfs-releases.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+
+      "Resource": "${aws_s3_bucket.download.arn}/zfs-releases/*"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
## Proposed Changes

This adds IAM users for titan-server and zfs-releases in order to publish assets to maven and download buckets, respectively.
