### PR TITLE
demo bucket

### DIFF
--- a/community/artifacts.tf
+++ b/community/artifacts.tf
@@ -1,0 +1,9 @@
+#
+# The artifacts bucket is a generic bucket for storing internal binaries and
+# artifacts. For example, it's used to hold the slack inviter serverless
+# deployment package.
+#
+
+resource "aws_s3_bucket" "artifacts" {
+    bucket      = "${var.project}-artifacts"
+}

--- a/community/maven.tf
+++ b/community/maven.tf
@@ -7,7 +7,6 @@
 resource "aws_s3_bucket" "maven" {
   bucket = "${var.project}-maven"
   acl = "public-read"
-  force_destroy = true
 
   website {
     index_document = "index.html"

--- a/community/titan-demo.tf
+++ b/community/titan-demo.tf
@@ -1,0 +1,53 @@
+#
+# Configure a demo bucket with public read access.
+#
+
+resource "aws_s3_bucket" "demo" {
+  bucket = "${var.project}-demo"
+  acl = "public-read"
+}
+
+# Public access policy for all objects
+resource "aws_s3_bucket_policy" "demo" {
+  bucket = "${aws_s3_bucket.demo.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AddPerm",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+
+      "Resource": "${aws_s3_bucket.demo.arn}/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "titan-demo" {
+  name = "titan-demo"
+  path = "/automation/"
+}
+
+resource "aws_iam_user_policy" "titan-demo-bucket" {
+  name = "titan-demo-bucket"
+  user = "${aws_iam_user.titan-demo.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+
+      "Resource": "${aws_s3_bucket.demo.arn}/*"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
## Proposed Changes

This adds a 'demo' bucket for playing demo assets (namely repos) along with two hello world examples. There was also an 'artifacts' bucket I had used for the slack inviter but forgot to merge, so I included that as well.