### PR TITLE
add bucket for test data

### DIFF
--- a/community/test.tf
+++ b/community/test.tf
@@ -1,0 +1,7 @@
+#
+# Common test resources for various endtoend tests requiring S3.
+#
+
+resource "aws_s3_bucket" "test" {
+  bucket = "${var.project}-testdata"
+}

--- a/community/titan-server.tf
+++ b/community/titan-server.tf
@@ -1,6 +1,6 @@
 #
-# Infrastructure required for titan-server automation. This is just a user
-# with permission to write objects to the maven bucket.
+# Infrastructure required for titan-server automation. This includes a user
+# with permission to write objects to the maven and test buckets.
 #
 
 resource "aws_iam_user" "titan-server" {
@@ -21,6 +21,25 @@ resource "aws_iam_user_policy" "titan-server-maven" {
       "Action": "s3:PutObject",
 
       "Resource": "${aws_s3_bucket.maven.arn}/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy" "titan-server-test" {
+  name = "titan-server-test"
+  user = "${aws_iam_user.titan-server.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+
+      "Resource": "${aws_s3_bucket.test.arn}/*"
     }
   ]
 }


### PR DESCRIPTION
## Proposed Changes

This adds a generic community S3 bucket for end to end test artifacts. This will be used by titan-server end2end tests, among others. This also expands the titan-server IAM permissions to write to this new bucket.

## Testing

Deployed to production :-)