### PR TITLE
add resources for s3web provider

### DIFF
--- a/community/test.tf
+++ b/community/test.tf
@@ -1,7 +1,35 @@
 #
-# Common test resources for various endtoend tests requiring S3.
+# Common test resources for various endtoend tests requiring S3. This is also
+# made publicly read-only to support testing the s3web provider
+# (which requires HTTP access).
 #
 
 resource "aws_s3_bucket" "test" {
   bucket = "${var.project}-testdata"
+  acl = "public-read"
+
+  website {
+    index_document = "index.html"
+  }
+}
+
+# Public access policy for all objects
+resource "aws_s3_bucket_policy" "test" {
+  bucket = "${aws_s3_bucket.test.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AddPerm",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+
+      "Resource": "${aws_s3_bucket.test.arn}/*"
+    }
+  ]
+}
+EOF
 }

--- a/community/titan-demo.tf
+++ b/community/titan-demo.tf
@@ -1,10 +1,15 @@
 #
-# Configure a demo bucket with public read access.
+# Configure a demo bucket with public read access. We also configure a static
+# website at http://demo.titan-data.io.
 #
 
 resource "aws_s3_bucket" "demo" {
   bucket = "${var.project}-demo"
   acl = "public-read"
+
+  website {
+    index_document = "index.html"
+  }
 }
 
 # Public access policy for all objects
@@ -50,4 +55,64 @@ resource "aws_iam_user_policy" "titan-demo-bucket" {
   ]
 }
 EOF
+}
+
+# CloudFront
+resource "aws_cloudfront_distribution" "demo" {
+  provider              = "aws.us-east-1"
+  origin {
+    domain_name         = "${aws_s3_bucket.demo.bucket_domain_name}"
+    origin_id           = "${aws_s3_bucket.demo.id}-origin"
+  }
+
+  enabled               = true
+  aliases               = [ "demo.titan-data.io" ]
+  default_root_object   = "index.html"
+  price_class           = "PriceClass_100"
+
+  default_cache_behavior {
+    allowed_methods     = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH",
+                            "POST", "PUT" ]
+    cached_methods      = [ "GET", "HEAD" ]
+    target_origin_id    = "${aws_s3_bucket.demo.id}-origin"
+    forwarded_values {
+      query_string      = true
+      cookies {
+        forward         = "all"
+      }
+    }
+    viewer_protocol_policy = "allow-all"
+  }
+
+  logging_config {
+    include_cookies     = false
+    bucket              = "${aws_s3_bucket.logs.bucket_domain_name}"
+    prefix              = "demo-site/"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn         = "${aws_acm_certificate_validation.main.certificate_arn}"
+    ssl_support_method          = "sni-only"
+    minimum_protocol_version    = "TLSv1.1_2016"
+  }
+}
+
+
+# DNS
+resource "aws_route53_record" "demo" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name    = "demo"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.demo.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.demo.hosted_zone_id}"
+    evaluate_target_health = false
+  }
 }


### PR DESCRIPTION
## Proposed Changes

This configures the endtoend test data bucket to have a read-only website so it can be used for testing the S3 web provider.

## Testing

Applied to production. Ran S3web tests. Ran curl from demo.titan-data.io and confirmed availability.