### PR TITLE
add titan remotes user

### DIFF
--- a/community/titan-remotes.tf
+++ b/community/titan-remotes.tf
@@ -1,0 +1,28 @@
+#
+# Infrastructure required for our various remote providers that need to push
+# artifacts to the maven bucket.
+#
+
+resource "aws_iam_user" "titan-remotes" {
+  name = "titan-remotes"
+  path = "/automation/"
+}
+
+resource "aws_iam_user_policy" "titan-remotes-maven" {
+  name = "titan-remotes-maven"
+  user = "${aws_iam_user.titan-remotes.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+
+      "Resource": "${aws_s3_bucket.maven.arn}/*"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
## Proposed Changes

As we separate out the remote providers, I'm going to be adding a number of repositories for each remote. These will all need common privileges to push artifacts to the maven bucket. I thought about having a dedicated user for each, but that seemed overkill for now. So I just created a single "remotes" user, and we can have an access key for repo that needs it.

## Testing

Applied the changes in prod!